### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/delegates/OPPDirectEditDelegate.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/delegates/OPPDirectEditDelegate.java
@@ -14,6 +14,10 @@ import com.vainolo.phd.opp.editor.part.OPPNamedElementCellEditorLocator;
 import com.vainolo.phd.opp.editor.part.OPPNamedElementDirectEditManager;
 
 public class OPPDirectEditDelegate {
+
+  private OPPDirectEditDelegate() {
+  }
+
   public static void performDirectEditing(GraphicalEditPart editPart, SmartLabelFigure textFigure) {
     OPPNamedElementDirectEditManager manager;
     manager = new OPPNamedElementDirectEditManager(editPart, TextCellEditor.class,

--- a/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/OPPProcessInstanceFactory.java
+++ b/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/OPPProcessInstanceFactory.java
@@ -49,6 +49,9 @@ import com.vainolo.phd.opp.utilities.OPPFileUtils;
 
 public class OPPProcessInstanceFactory {
 
+  private OPPProcessInstanceFactory() {
+  }
+
   public static OPPProcessInstance createExecutableInstance(OPPObjectProcessDiagram opd) {
     switch (opd.getKind()) {
     case COMPOUND:

--- a/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/OPPFileUtils.java
+++ b/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/OPPFileUtils.java
@@ -25,6 +25,9 @@ import com.vainolo.phd.opp.model.OPPThing;
 
 public class OPPFileUtils {
 
+  private OPPFileUtils() {
+  }
+
   public static OPPObjectProcessDiagram loadOPPFile(String uri) {
     OPPObjectProcessDiagram opd;
     ResourceSet resourceSet = new ResourceSetImpl();

--- a/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/OPPStrings.java
+++ b/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/OPPStrings.java
@@ -15,4 +15,6 @@ public class OPPStrings {
   public static final String SKIP_PARAMETER = "Skipping instance of {0} because conditional parameter {1} is empty.";
   public static final String SKIP_PARAMETER_STATE = "Skipping instance of {0} because conditional parameter {1} is not in state {2}.";
 
+  private OPPStrings() {
+  }
 }

--- a/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/OPPTestUtilities.java
+++ b/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/OPPTestUtilities.java
@@ -16,6 +16,10 @@ import com.vainolo.phd.opp.model.OPPProcess;
 import com.vainolo.phd.opp.model.OPPThing;
 
 public class OPPTestUtilities {
+
+  private OPPTestUtilities() {
+  }
+
   private static OPPNamedElement setName(OPPNamedElement namedElement, String name) {
     namedElement.setName(name);
     return namedElement;

--- a/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPLiterals.java
+++ b/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPLiterals.java
@@ -11,6 +11,10 @@ import java.math.BigDecimal;
 import com.google.common.base.Preconditions;
 
 public class OPPLiterals {
+
+  private  OPPLiterals() {
+  }
+
   public static boolean isOPMNumberLiteral(String input) {
     return input.matches("^\\d.*");
   }

--- a/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPNodeExtensions.java
+++ b/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPNodeExtensions.java
@@ -17,6 +17,9 @@ import com.vainolo.phd.opp.model.OPPStructuralLinkPart;
 
 public class OPPNodeExtensions {
 
+  private OPPNodeExtensions() {
+  }
+
   public static Collection<OPPLink> getIncomingStructuralLinks(OPPNode node) {
     return node.getIncomingLinks().stream().filter(l -> l instanceof OPPStructuralLinkPart).collect(Collectors.toList());
     // return Collections2.filter(node.getIncomingLinks(), IsOPPStructuralLink.INSTANCE);

--- a/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPStateExtensions.java
+++ b/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPStateExtensions.java
@@ -19,6 +19,9 @@ public class OPPStateExtensions {
   private static Predicate<OPPLink> isAgentLink = new IsAgentLink();
   private static Predicate<OPPLink> isDataLink = new IsDataLink();
 
+  private OPPStateExtensions() {
+  }
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public static Collection<OPPProceduralLink> findOutgoingProceduralLinks(OPPState state) {
     return (Collection) state.getOutgoingLinks().stream().filter(l -> l instanceof OPPProceduralLink).collect(Collectors.toList());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
