### PR TITLE
The operator ("<>") should be used.

### DIFF
--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/command/OPPDeleteNodeCommand.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/command/OPPDeleteNodeCommand.java
@@ -42,9 +42,9 @@ public final class OPPDeleteNodeCommand extends Command {
    * structures.
    */
   private void detachLinks() {
-    links = new ArrayList<OPPLink>();
-    linkSources = new HashMap<OPPLink, OPPNode>();
-    linkTargets = new HashMap<OPPLink, OPPNode>();
+    links = new ArrayList<>();
+    linkSources = new HashMap<>();
+    linkTargets = new HashMap<>();
     links.addAll(node.getIncomingLinks());
     links.addAll(node.getOutgoingLinks());
     for (OPPLink link : links) {

--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPObjectProcessDiagramEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPObjectProcessDiagramEditPart.java
@@ -59,7 +59,7 @@ public class OPPObjectProcessDiagramEditPart extends AbstractGraphicalEditPart {
   @Override
   protected List<OPPNode> getModelChildren() {
     OPPObjectProcessDiagram opd = (OPPObjectProcessDiagram) getModel();
-    List<OPPNode> nodes = new ArrayList<OPPNode>(opd.getNodes());
+    List<OPPNode> nodes = new ArrayList<>(opd.getNodes());
     return nodes;
   }
 
@@ -86,7 +86,7 @@ public class OPPObjectProcessDiagramEditPart extends AbstractGraphicalEditPart {
   @Override
   public Object getAdapter(@SuppressWarnings("rawtypes") Class key) {
     if (key == SnapToHelper.class) {
-      List<SnapToHelper> helpers = new ArrayList<SnapToHelper>();
+      List<SnapToHelper> helpers = new ArrayList<>();
       if (Boolean.TRUE.equals(getViewer().getProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED))) {
         helpers.add(new SnapToGeometry(this));
       }

--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPProceduralLinkEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPProceduralLinkEditPart.java
@@ -84,7 +84,7 @@ public class OPPProceduralLinkEditPart extends OPPLinkEditPart {
 
     Connection connection = getConnectionFigure();
     List<OPPPoint> modelConstraint = getModel().getBendpoints();
-    List<AbsoluteBendpoint> figureConstraint = new ArrayList<AbsoluteBendpoint>();
+    List<AbsoluteBendpoint> figureConstraint = new ArrayList<>();
     for (OPPPoint p : modelConstraint) {
       figureConstraint.add(new AbsoluteBendpoint(p.getX(), p.getY()));
     }

--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPStateEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPStateEditPart.java
@@ -90,7 +90,7 @@ public class OPPStateEditPart extends OPPNodeEditPart {
   @Override
   public Object getAdapter(@SuppressWarnings("rawtypes") Class key) {
     if (key == SnapToHelper.class) {
-      List<SnapToHelper> helpers = new ArrayList<SnapToHelper>();
+      List<SnapToHelper> helpers = new ArrayList<>();
       if (Boolean.TRUE.equals(getViewer().getProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED))) {
         helpers.add(new SnapToGeometry(this));
       }

--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPStructuralLinkEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPStructuralLinkEditPart.java
@@ -45,7 +45,7 @@ public class OPPStructuralLinkEditPart extends OPPLinkEditPart {
     super.refreshVisuals();
     Connection connection = getConnectionFigure();
     List<OPPPoint> modelConstraint = getModel().getBendpoints();
-    List<AbsoluteBendpoint> figureConstraint = new ArrayList<AbsoluteBendpoint>();
+    List<AbsoluteBendpoint> figureConstraint = new ArrayList<>();
     for (OPPPoint p : modelConstraint) {
       figureConstraint.add(new AbsoluteBendpoint(p.getX(), p.getY()));
     }

--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPThingEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPThingEditPart.java
@@ -55,7 +55,7 @@ public abstract class OPPThingEditPart extends OPPNodeEditPart {
   @Override
   public Object getAdapter(@SuppressWarnings("rawtypes") final Class key) {
     if (key == SnapToHelper.class) {
-      final List<SnapToHelper> helpers = new ArrayList<SnapToHelper>();
+      final List<SnapToHelper> helpers = new ArrayList<>();
       if (Boolean.TRUE.equals(getViewer().getProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED)))
         helpers.add(new SnapToGeometry(this));
       if (Boolean.TRUE.equals(getViewer().getProperty(SnapToGrid.PROPERTY_GRID_ENABLED)))

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPContainerImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPContainerImpl.java
@@ -74,7 +74,7 @@ public abstract class OPPContainerImpl extends OPPElementImpl implements OPPCont
    */
   public EList<OPPNode> getNodes() {
     if (nodes == null) {
-      nodes = new EObjectContainmentWithInverseEList<OPPNode>(OPPNode.class, this, OPPPackage.OPP_CONTAINER__NODES, OPPPackage.OPP_NODE__CONTAINER);
+      nodes = new EObjectContainmentWithInverseEList<>(OPPNode.class, this, OPPPackage.OPP_CONTAINER__NODES, OPPPackage.OPP_NODE__CONTAINER);
     }
     return nodes;
   }

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPLinkImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPLinkImpl.java
@@ -389,7 +389,7 @@ public class OPPLinkImpl extends OPPElementImpl implements OPPLink {
    */
   public EList<OPPPoint> getBendpoints() {
     if (bendpoints == null) {
-      bendpoints = new EObjectContainmentEList<OPPPoint>(OPPPoint.class, this, OPPPackage.OPP_LINK__BENDPOINTS);
+      bendpoints = new EObjectContainmentEList<>(OPPPoint.class, this, OPPPackage.OPP_LINK__BENDPOINTS);
     }
     return bendpoints;
   }

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPNodeImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPNodeImpl.java
@@ -197,7 +197,7 @@ public abstract class OPPNodeImpl extends OPPElementImpl implements OPPNode {
    */
   public EList<OPPLink> getIncomingLinks() {
     if (incomingLinks == null) {
-      incomingLinks = new EObjectWithInverseResolvingEList<OPPLink>(OPPLink.class, this, OPPPackage.OPP_NODE__INCOMING_LINKS, OPPPackage.OPP_LINK__TARGET);
+      incomingLinks = new EObjectWithInverseResolvingEList<>(OPPLink.class, this, OPPPackage.OPP_NODE__INCOMING_LINKS, OPPPackage.OPP_LINK__TARGET);
     }
     return incomingLinks;
   }
@@ -209,7 +209,7 @@ public abstract class OPPNodeImpl extends OPPElementImpl implements OPPNode {
    */
   public EList<OPPLink> getOutgoingLinks() {
     if (outgoingLinks == null) {
-      outgoingLinks = new EObjectWithInverseResolvingEList<OPPLink>(OPPLink.class, this, OPPPackage.OPP_NODE__OUTGOING_LINKS, OPPPackage.OPP_LINK__SOURCE);
+      outgoingLinks = new EObjectWithInverseResolvingEList<>(OPPLink.class, this, OPPPackage.OPP_NODE__OUTGOING_LINKS, OPPPackage.OPP_LINK__SOURCE);
     }
     return outgoingLinks;
   }

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPObjectProcessDiagramImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPObjectProcessDiagramImpl.java
@@ -206,7 +206,7 @@ public class OPPObjectProcessDiagramImpl extends OPPContainerImpl implements OPP
    */
   public EList<OPPLink> getLinks() {
     if (links == null) {
-      links = new EObjectContainmentWithInverseEList<OPPLink>(OPPLink.class, this, OPPPackage.OPP_OBJECT_PROCESS_DIAGRAM__LINKS, OPPPackage.OPP_LINK__OPD);
+      links = new EObjectContainmentWithInverseEList<>(OPPLink.class, this, OPPPackage.OPP_OBJECT_PROCESS_DIAGRAM__LINKS, OPPPackage.OPP_LINK__OPD);
     }
     return links;
   }

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPProceduralLinkImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPProceduralLinkImpl.java
@@ -121,7 +121,7 @@ public class OPPProceduralLinkImpl extends OPPLinkImpl implements OPPProceduralL
    */
   public EList<String> getSubKinds() {
     if (subKinds == null) {
-      subKinds = new EDataTypeUniqueEList<String>(String.class, this, OPPPackage.OPP_PROCEDURAL_LINK__SUB_KINDS);
+      subKinds = new EDataTypeUniqueEList<>(String.class, this, OPPPackage.OPP_PROCEDURAL_LINK__SUB_KINDS);
     }
     return subKinds;
   }

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPThingImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPThingImpl.java
@@ -185,7 +185,7 @@ public abstract class OPPThingImpl extends OPPNodeImpl implements OPPThing {
    */
   public EList<OPPNode> getNodes() {
     if (nodes == null) {
-      nodes = new EObjectContainmentWithInverseEList<OPPNode>(OPPNode.class, this, OPPPackage.OPP_THING__NODES, OPPPackage.OPP_NODE__CONTAINER);
+      nodes = new EObjectContainmentWithInverseEList<>(OPPNode.class, this, OPPPackage.OPP_THING__NODES, OPPPackage.OPP_NODE__CONTAINER);
     }
     return nodes;
   }

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/provider/OPPItemProviderAdapterFactory.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/provider/OPPItemProviderAdapterFactory.java
@@ -61,7 +61,7 @@ public class OPPItemProviderAdapterFactory extends OPPAdapterFactory implements 
    * <!-- end-user-doc -->
    * @generated
    */
-  protected Collection<Object> supportedTypes = new ArrayList<Object>();
+  protected Collection<Object> supportedTypes = new ArrayList<>();
 
   /**
    * This constructs an instance.

--- a/sandbox/tests/src/tests/model/Canvas.java
+++ b/sandbox/tests/src/tests/model/Canvas.java
@@ -19,7 +19,7 @@ public class Canvas extends Observable {
 	
 	public List<Node> getNodes() {
 		if(nodes == null) {
-			nodes = new ArrayList<Node>();
+			nodes = new ArrayList<>();
 		}
 		return nodes; 
 	}

--- a/sandbox/tests/src/tests/model/Node.java
+++ b/sandbox/tests/src/tests/model/Node.java
@@ -17,9 +17,9 @@ public class Node extends Observable {
 	public Node(int x, int y, Node parent) {
 		size = 50;
 		setLocation(new Point(x, y));
-		sourceLinks = new ArrayList<Link>();
-		targetLinks = new ArrayList<Link>();
-		children = new ArrayList<Node>();
+		sourceLinks = new ArrayList<>();
+		targetLinks = new ArrayList<>();
+		children = new ArrayList<>();
 		this.parent = parent;
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
