### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPElementImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPElementImpl.java
@@ -159,7 +159,7 @@ public abstract class OPPElementImpl extends EObjectImpl implements OPPElement {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (id: ");
     result.append(id);
     result.append(')');

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPLabelImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPLabelImpl.java
@@ -246,7 +246,7 @@ public class OPPLabelImpl extends OPPNodeImpl implements OPPLabel {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (name: ");
     result.append(name);
     result.append(", alignment: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPLinkImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPLinkImpl.java
@@ -583,7 +583,7 @@ public class OPPLinkImpl extends OPPElementImpl implements OPPLink {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (sourceDecoration: ");
     result.append(sourceDecoration);
     result.append(", targetDecoration: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPNamedElementImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPNamedElementImpl.java
@@ -212,7 +212,7 @@ public abstract class OPPNamedElementImpl extends EObjectImpl implements OPPName
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (name: ");
     result.append(name);
     result.append(", alignment: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPNodeImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPNodeImpl.java
@@ -566,7 +566,7 @@ public abstract class OPPNodeImpl extends OPPElementImpl implements OPPNode {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (width: ");
     result.append(width);
     result.append(", height: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPObjectImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPObjectImpl.java
@@ -262,7 +262,7 @@ public class OPPObjectImpl extends OPPThingImpl implements OPPObject {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (parameter: ");
     result.append(parameter);
     result.append(", global: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPObjectProcessDiagramImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPObjectProcessDiagramImpl.java
@@ -425,7 +425,7 @@ public class OPPObjectProcessDiagramImpl extends OPPContainerImpl implements OPP
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (name: ");
     result.append(name);
     result.append(", alignment: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPProceduralLinkImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPProceduralLinkImpl.java
@@ -205,7 +205,7 @@ public class OPPProceduralLinkImpl extends OPPLinkImpl implements OPPProceduralL
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (kind: ");
     result.append(kind);
     result.append(", subKinds: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPProcessImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPProcessImpl.java
@@ -211,7 +211,7 @@ public class OPPProcessImpl extends OPPThingImpl implements OPPProcess {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (kind: ");
     result.append(kind);
     result.append(", order: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPStateImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPStateImpl.java
@@ -298,7 +298,7 @@ public class OPPStateImpl extends OPPNodeImpl implements OPPState {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (name: ");
     result.append(name);
     result.append(", alignment: ");

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPStructuralLinkAggregatorImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPStructuralLinkAggregatorImpl.java
@@ -159,7 +159,7 @@ public class OPPStructuralLinkAggregatorImpl extends OPPNodeImpl implements OPPS
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (kind: ");
     result.append(kind);
     result.append(')');

--- a/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPThingImpl.java
+++ b/com.vainolo.phd.opp.model/src/com/vainolo/phd/opp/model/impl/OPPThingImpl.java
@@ -489,7 +489,7 @@ public abstract class OPPThingImpl extends OPPNodeImpl implements OPPThing {
   public String toString() {
     if (eIsProxy()) return super.toString();
 
-    StringBuffer result = new StringBuffer(super.toString());
+    StringBuilder result = new StringBuilder(super.toString());
     result.append(" (name: ");
     result.append(name);
     result.append(", alignment: ");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.
