### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPObjectProcessDiagramEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPObjectProcessDiagramEditPart.java
@@ -93,7 +93,7 @@ public class OPPObjectProcessDiagramEditPart extends AbstractGraphicalEditPart {
       if (Boolean.TRUE.equals(getViewer().getProperty(SnapToGrid.PROPERTY_GRID_ENABLED))) {
         helpers.add(new SnapToGrid(this));
       }
-      if (helpers.size() == 0) {
+      if (helpers.isEmpty()) {
         return null;
       } else {
         return new CompoundSnapToHelper(helpers.toArray(new SnapToHelper[0]));

--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPStateEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPStateEditPart.java
@@ -97,7 +97,7 @@ public class OPPStateEditPart extends OPPNodeEditPart {
       if (Boolean.TRUE.equals(getViewer().getProperty(SnapToGrid.PROPERTY_GRID_ENABLED))) {
         helpers.add(new SnapToGrid(this));
       }
-      if (helpers.size() == 0) {
+      if (helpers.isEmpty()) {
         return null;
       } else {
         return new CompoundSnapToHelper(helpers.toArray(new SnapToHelper[0]));

--- a/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPThingEditPart.java
+++ b/com.vainolo.phd.opp.editor/src/com/vainolo/phd/opp/editor/part/OPPThingEditPart.java
@@ -60,7 +60,7 @@ public abstract class OPPThingEditPart extends OPPNodeEditPart {
         helpers.add(new SnapToGeometry(this));
       if (Boolean.TRUE.equals(getViewer().getProperty(SnapToGrid.PROPERTY_GRID_ENABLED)))
         helpers.add(new SnapToGrid(this));
-      if (helpers.size() == 0)
+      if (helpers.isEmpty())
         return null;
       else
         return new CompoundSnapToHelper(helpers.toArray(new SnapToHelper[0]));

--- a/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/inzoomedprocessinstance/OPPInZoomedProcessArgumentHandler.java
+++ b/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/inzoomedprocessinstance/OPPInZoomedProcessArgumentHandler.java
@@ -70,7 +70,7 @@ public class OPPInZoomedProcessArgumentHandler {
 
     // Fill up remaining parameters using the remaining arguments
     Iterator<String> remainingParameterNamesIterator = remainingParameterNames.iterator();
-    while (arguments.size() > 0 && remainingParameterNamesIterator.hasNext()) {
+    while (!arguments.isEmpty() && remainingParameterNamesIterator.hasNext()) {
       String parameterName = remainingParameterNamesIterator.next();
       OPPObjectInstance value = getArgumentValueFromHeapAndClearIfNecessary(arguments.remove(0));
       instance.setArgument(parameterName, value);
@@ -78,7 +78,7 @@ public class OPPInZoomedProcessArgumentHandler {
     }
 
     // In case there are left arguments, pass them as parameters with default names
-    if (arguments.size() > 0) {
+    if (!arguments.isEmpty()) {
       int argNumber = 0;
       for (OPPArgument argument : arguments) {
         OPPObjectInstance value = getArgumentValueFromHeapAndClearIfNecessary(argument);

--- a/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/inzoomedprocessinstance/OPPInZoomedProcessExecutableInstance.java
+++ b/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/inzoomedprocessinstance/OPPInZoomedProcessExecutableInstance.java
@@ -102,7 +102,7 @@ public class OPPInZoomedProcessExecutableInstance extends OPPAbstractProcessInst
 
   private void calculateNextProcesses() {
     List<OPPProcess> nextProcesses = pc.getNextProcesses(P_waiting, P_executing.values());
-    if (nextProcesses.size() > 0) {
+    if (!nextProcesses.isEmpty()) {
       List<OPPProcess> P_skipped = nextProcesses.stream().filter(MUST_SKIP).collect(Collectors.toList());
       if (P_skipped.size() != nextProcesses.size()) {
         P_waiting.addAll(nextProcesses.stream().filter(MUST_SKIP.negate()).collect(Collectors.toSet()));
@@ -160,7 +160,7 @@ public class OPPInZoomedProcessExecutableInstance extends OPPAbstractProcessInst
         }
 
         Set<OPPProcess> invoked = findInvokedAndNotSkippedProcesses(executedProcess);
-        if (invoked.size() > 0) {
+        if (!invoked.isEmpty()) {
           executionMode = ExecutionMode.EVENT;
         }
 
@@ -170,7 +170,7 @@ public class OPPInZoomedProcessExecutableInstance extends OPPAbstractProcessInst
           executeReadyProcesses();
           break;
         case EVENT:
-          if (invoked.size() > 0) {
+          if (!invoked.isEmpty()) {
             P_ready.addAll(invoked);
             executeReadyProcesses();
           } else {
@@ -191,7 +191,7 @@ public class OPPInZoomedProcessExecutableInstance extends OPPAbstractProcessInst
       }
     }
 
-    if (P_waiting.size() > 0)
+    if (!P_waiting.isEmpty())
       logInfo("Finished execution of {0} with {1} waiting processes.", getName(), P_waiting.size());
 
   }

--- a/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/inzoomedprocessinstance/OPPInZoomedProcessIntanceProgramCounter.java
+++ b/com.vainolo.phd.opp.interpreter/src/com/vainolo/phd/opp/interpreter/inzoomedprocessinstance/OPPInZoomedProcessIntanceProgramCounter.java
@@ -60,7 +60,7 @@ public class OPPInZoomedProcessIntanceProgramCounter {
 
   public List<OPPProcess> getNextProcesses(Collection<OPPProcess> P_waiting, Collection<OPPProcess> P_executing) {
     List<OPPProcess> nextPossibleProcess = getProcessesAtPC();
-    if (nextPossibleProcess.size() == 0)
+    if (nextPossibleProcess.isEmpty())
       return Collections.emptyList();
 
     for (OPPProcess waitingProcess : P_waiting) {

--- a/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPObjectExtensions.java
+++ b/com.vainolo.phd.opp.utilities/src/com/vainolo/phd/opp/utilities/analysis/OPPObjectExtensions.java
@@ -54,7 +54,7 @@ public class OPPObjectExtensions {
    * Check if the {@link OPPObject} or one of its {@link OPPState}s has outgoing data links.
    */
   public boolean hasOutgoingDataLinks(OPPObject object) {
-    return findOutgoingDataLinks(object).size() > 0;
+    return !findOutgoingDataLinks(object).isEmpty();
   }
 
   /**
@@ -68,7 +68,7 @@ public class OPPObjectExtensions {
    * Check if the {@link OPPObject}, one of its {@link OPPState}s or one of its parts has outgoing procedural links.
    */
   public static boolean hasOutgoingProceduralLinksIncludingParts(OPPObject object) {
-    if (findOutgoingProceduralLinks(object).size() > 0) {
+    if (!findOutgoingProceduralLinks(object).isEmpty()) {
       return true;
     } else {
       for (OPPObject part : getParts(object)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.
